### PR TITLE
Fix horizontal scroll on mobile article pages

### DIFF
--- a/.vitepress/theme/components/HomeLayoutRedesign.vue
+++ b/.vitepress/theme/components/HomeLayoutRedesign.vue
@@ -756,6 +756,7 @@ const excerpt = computed(() => {
         'DM Sans',
         -apple-system,
         sans-serif;
+    overflow-x: hidden;
 }
 
 .container {
@@ -1787,6 +1788,35 @@ const excerpt = computed(() => {
 
     .toggle-section-inline {
         width: 100%;
+    }
+
+    .right-column {
+        padding: 32px 16px;
+    }
+
+    .article-detail-view,
+    .article-content {
+        max-width: 100%;
+        overflow-x: hidden;
+    }
+
+    .article-body :deep(pre),
+    .article-body :deep(div[class*="language-"]) {
+        max-width: calc(100vw - 32px);
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .article-body :deep(table) {
+        display: block;
+        max-width: calc(100vw - 32px);
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .article-body :deep(img) {
+        max-width: 100%;
+        height: auto;
     }
 }
 </style>

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -555,3 +555,36 @@ a:not(.topics):not(.truncate) {
         color: #1a1a1a;
     }
 }
+
+/* Mobile-specific styles to prevent horizontal overflow */
+@media (max-width: 768px) {
+    html, body {
+        overflow-x: hidden;
+        max-width: 100vw;
+    }
+
+    .prose div[class*="language-"],
+    .prose .vp-code-group {
+        max-width: 100%;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    .prose div[class*="language-"] pre {
+        max-width: 100%;
+        padding: 40px 16px 16px 16px;
+    }
+
+    .prose pre,
+    .prose code {
+        max-width: 100%;
+        word-wrap: break-word;
+    }
+
+    .prose table {
+        display: block;
+        max-width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -38,6 +38,13 @@
 @media screen and (max-width: 768px) {
     .prose img {
         max-height: 400px;
+        max-width: 100%;
+    }
+
+    /* Prevent horizontal scroll on mobile */
+    .prose pre,
+    .prose [class*="language-"] {
+        max-width: 100%;
     }
 }
 


### PR DESCRIPTION
- Add overflow-x: hidden to main container to prevent page-level horizontal scroll
- Constrain code blocks, pre elements, and tables to max-width: 100% on mobile
- Reduce right column padding on mobile (60px -> 16px) for better content fit
- Add mobile-specific styles for VitePress code blocks in style.css
- Ensure images are constrained to container width on mobile